### PR TITLE
Update style for reviewer names in final report tex

### DIFF
--- a/template/final-report/final-NO-SEND-report.tex
+++ b/template/final-report/final-NO-SEND-report.tex
@@ -20,7 +20,7 @@
 \chapter{Comments from the house}
 Thanks to the group of reviewers for this packet:
 
-\lstinputlisting[numbers=none,basicstyle=\sffamily\small]{../tex/names.txt}
+\lstinputlisting[numbers=none,basicstyle=\ttfamily\footnotesize]{../tex/names.txt}
 
 The comments here are simultaneously
 based on those submitted by the reviewers,


### PR DESCRIPTION
Copied over the line from `internal-NO-SEND-probs.tex`